### PR TITLE
Fix bugs with list and keys.

### DIFF
--- a/src/components/containers/CountryOverview/CountryOverview.js
+++ b/src/components/containers/CountryOverview/CountryOverview.js
@@ -68,11 +68,12 @@ const CountryOverview = ({ className, sectors, cases }) => {
             de isolamento e quarentena.
           </Text>
         </article>
-        {sectors.map(item => (
+        {sectors.map((item, indicatorKey) => (
           <Indicator
             icon={<SectorIcon sector={item.id} />}
             label={`${item.name}`}
             value={item?.total_estimated_impact}
+            key={indicatorKey}
           />
         ))}
       </div>

--- a/src/components/containers/EventsOverview/EventsOverview.js
+++ b/src/components/containers/EventsOverview/EventsOverview.js
@@ -21,14 +21,14 @@ const EventsOverview = ({ className, events, sectors }) => {
         </Text>
 
         <section className='events-overview__container'>
-          {sectors.map(item => (
-            <Event scroll={false} sector={item.id} title={item.name}>
+          {sectors.map((item, eventKey) => (
+            <Event scroll={false} sector={item.id} title={item.name} key={eventKey}>
               {events?.[item.id] &&
                 events?.[item.id].results
                   .filter((_, idx) => idx < 2)
-                  .map(item => (
+                  .map((item, eventItemKey) => (
                     <Event.Item
-                    key={JSON.stringify(item)}
+                    key={eventItemKey}
                       event={item}
                       city={item?.city?.name}
                       status={item.status_type}


### PR DESCRIPTION
Issue: #17 

It's ok.

```     
const todoItems = todos.map((todo, index) =>
  // Only do this if items have no stable IDs
  <li key={index}>
    {todo.text}
  </li>
);
```

It's not ok

```     
// Wrong! There is no need to specify the key here:
    <li key={value.toString()}>
      {value}
    </li>

```